### PR TITLE
alarms: only send email on first alarm occurrence; reset count histor…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
@@ -67,7 +67,6 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
-
 import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -133,6 +132,7 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                 Collection<LogEntry> dup
                         = (Collection<LogEntry>) query.executeWithArray(entry.getKey());
                 logger.trace("duplicate? {}", dup);
+
                 if (dup != null && !dup.isEmpty()) {
                     if (dup.size() > 1) {
                         throw new RuntimeException
@@ -140,14 +140,33 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                                  + " more than one alarm with the same id: "
                                  + entry.getKey());
                     }
+
                     LogEntry original = dup.iterator().next();
-                    original.setLastUpdate(entry.getLastUpdate());
-                    original.setReceived(original.getReceived() + 1);
-                    /*
-                     * this needs to be done or else newly arriving instances will
-                     * not be tracked if this type has been closed previously
-                     */
-                    original.setClosed(false);
+                    entry.setLastUpdate(original.getLastUpdate());
+
+                    int received = original.getReceived();
+
+                    if (original.isClosed()) {
+                        /*
+                         * this needs to be done or else newly arriving instances will
+                         * not be tracked if this type has been closed previously
+                         */
+                        original.setClosed(false);
+
+                        /*
+                         * Treat the alarm as a new instance by restarting
+                         * its history.  This guarantees a new alert will
+                         * be sent and plugins called as if it were a
+                         * first occurrence.
+                         */
+                        received = 1;
+                    } else {
+                        ++received;
+                    }
+
+                    original.setReceived(received);
+                    entry.setReceived(received);
+
                     /*
                      * original is not detached so it will be updated on commit
                      */

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
@@ -121,6 +121,14 @@ public class LogEntryHandler {
                 int priority = priorityMap.getPriority(entry.getType()).ordinal();
 
                 /*
+                 * Store the alarm.
+                 *
+                 * If this is a duplicate, the store will increment
+                 * the received field.
+                 */
+                store.put(entry);
+
+                /*
                  * The history log parses out all alerts above a certain
                  * priority. This is just a convenience for sifting messages
                  * from the normal domain log and recording them them using the
@@ -133,15 +141,13 @@ public class LogEntryHandler {
                 }
 
                 /*
-                 * Remote messages which are indeed alarms/alerts can be sent as
-                 * email.
+                 * Post-process if this is a new alarm.
                  */
-                if (emailEnabled && priority >= emailThreshold.ordinal()) {
-                    setType(event);
-                    emailAppender.doAppend(event);
+                if (entry.getReceived() == 1) {
+                    if (emailEnabled && priority >= emailThreshold.ordinal()) {
+                        emailAppender.doAppend(event);
+                    }
                 }
-
-                store.put(entry);
             } else if (!storeOnlyAlarms) {
                 store.put(entry);
             }


### PR DESCRIPTION
…y on reopened alarm

combines patches #9633 and #9647

Motivation:

9555, which modified the log entry handling to be able to use listener

extensions to process alarms, also modified the handling of alarms such
that this post-processing, as well as email, occurs only on the first
instance of potentially duplicate alarms.   This behavior is currently
not enforced for the stable branches with respect to alarm emails.

Modification:

Backport the change which affects the handling of alarm emails.

Result:

Alarm email notifications are sent only on the first occurrence
of given alarm (i.e., for that alarm instance's unique ID).

---

Motivation:

9555 (master) and #9633 (2.13-2.16)

corrected the behavior of the log entry handler such that emails
(and eventually plugin calls) are triggered only on the first
occurrence of an alarm (id).

This patch finishes that correction as regards alarms which are
in the closed state.  If an alarm has been closed and not deleted,
but then occurs again, the count history (the 'received' attribute)
should be reset to 1, in order to treat this as a new (set of)
occurrences, and to guarantee a new notification will be sent.

Modification:

Reset the received value to 1 if the alarm is being reopened.

Result:

Notification and triggering of plugins will occur on reopened
alarms.

Acked-by:  Dmitry
Acked-by:  Paul
