### PR TITLE
fix alarms.db.url-when-type-is-rdbms

### DIFF
--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -243,7 +243,7 @@ alarms.plugin!alarms=${alarms.dir}
 #
 (immutable)alarms.db.url-when-type-is-off=off
 (immutable)alarms.db.url-when-type-is-xml=xml:file:${alarms.db.xml.path}
-(immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.rdbms.type}://${alarms.db.host}/${alarms.db.name}
+(immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.type}://${alarms.db.host}/${alarms.db.name}
 alarms.db.url=${alarms.db.url-when-type-is-${alarms.db.type}}
 
 #  -----------------------------------------------------------------------

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -243,7 +243,7 @@ alarms.plugin!alarms=${alarms.dir}
 #
 (immutable)alarms.db.url-when-type-is-off=off
 (immutable)alarms.db.url-when-type-is-xml=xml:file:${alarms.db.xml.path}
-(immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.type}://${alarms.db.host}/${alarms.db.name}
+(immutable)alarms.db.url-when-type-is-rdbms=jdbc:postgresql://${alarms.db.host}/${alarms.db.name}
 alarms.db.url=${alarms.db.url-when-type-is-${alarms.db.type}}
 
 #  -----------------------------------------------------------------------


### PR DESCRIPTION
(immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.rdbms.type}://${alarms.db.host}/${alarms.db.name}

to

(immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.type}://${alarms.db.host}/${alarms.db.name}