### PR TITLE
Remove subject uid filter on transfers in order to

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -69,7 +69,6 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -77,16 +76,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TransferInfo;
 
-import org.dcache.auth.Subjects;
 import org.dcache.restful.providers.SnapshotList;
 import org.dcache.restful.services.transfers.TransferInfoService;
-import org.dcache.restful.util.RequestUser;
 
 /**
  * <p>RESTful API to the {@link TransferInfoService} service.</p>
@@ -152,15 +148,9 @@ public final class TransferResources {
                                                    @DefaultValue("door,waiting")
                                                    @QueryParam("sort") String sort) {
         try {
-            RequestUser.checkAuthenticated();
-
-            String suid = RequestUser.isAdmin() ? null :
-                            String.valueOf(Subjects.getUid(RequestUser.getSubject()));
-
             return service.get(token,
                                offset,
                                limit,
-                               suid,
                                state,
                                door,
                                domain,
@@ -172,8 +162,6 @@ public final class TransferResources {
                                pool,
                                client,
                                sort);
-        } catch (NoSuchElementException e) {
-            throw new ForbiddenException("User subject must contain uid to access transfers.");
         } catch (CacheException e) {
             throw new InternalServerErrorException(e);
         }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
@@ -90,7 +90,6 @@ public interface TransferInfoService {
      *                  without a token (refresh).
      * @param offset    Return transfers beginning at this index.
      * @param limit     Return at most this number of items.
-     * @param suid      Return transfers only belonging to this user (null returns all).
      * @param state     Filter on state.
      * @param door      Filter on door.
      * @param domain    Filter on domain.
@@ -109,7 +108,6 @@ public interface TransferInfoService {
     SnapshotList<TransferInfo> get(UUID token,
                                    Integer offset,
                                    Integer limit,
-                                   String suid,
                                    String state,
                                    String door,
                                    String domain,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
@@ -259,7 +259,6 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                   null,
                                   null,
                                   null,
-                                  null,
                                   null);
             List<TransferInfo> snapshot = result.getItems();
 
@@ -348,17 +347,11 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         };
     }
 
-    private static Predicate<TransferInfo> getFilter(String subjectUid,
-                                                     String state, String door,
+    private static Predicate<TransferInfo> getFilter(String state, String door,
                                                      String domain, String protocol,
                                                      String uid, String gid,
                                                      String vomsgroup, String pnfsid,
                                                      String pool, String client) {
-        Predicate<TransferInfo> matchesSubject =
-                        (info) -> subjectUid == null
-                                        || Strings.emptyToNull(info.getUid()) == null  // allow all users to see anonymous transfers
-                                        || info.getUid().equals(subjectUid);
-
         Predicate<TransferInfo> matchesState =
                         (info) -> state == null || Strings.nullToEmpty(info.getMoverStatus())
                                                           .contains(state);
@@ -390,10 +383,10 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                         (info) -> client == null || Strings.nullToEmpty(info.getReplyHost())
                                                           .contains(client);
 
-        return matchesSubject.and(matchesState).and(matchesDoor)
-                             .and(matchesDomain).and(matchesProtocol)
-                             .and(matchesUid).and(matchesGid).and(matchesVomsGroup)
-                             .and(matchesPnfsid).and(matchesPool).and(matchesClient);
+        return matchesState.and(matchesDoor)
+                           .and(matchesDomain).and(matchesProtocol)
+                           .and(matchesUid).and(matchesGid).and(matchesVomsGroup)
+                           .and(matchesPnfsid).and(matchesPool).and(matchesClient);
     }
 
     /**
@@ -417,7 +410,6 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
     public SnapshotList<TransferInfo> get(UUID token,
                                           Integer offset,
                                           Integer limit,
-                                          String suid,
                                           String state,
                                           String door,
                                           String domain,
@@ -429,8 +421,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                           String pool,
                                           String client,
                                           String sort) throws CacheException {
-        Predicate<TransferInfo> filter = getFilter(suid,
-                                                   state, door, domain, protocol,
+        Predicate<TransferInfo> filter = getFilter(state, door, domain, protocol,
                                                    uid, gid, vomsgroup,
                                                    pnfsid, pool, client);
         if (Strings.isNullOrEmpty(sort)) {


### PR DESCRIPTION
open up visibility of all transfers to all users.

eliminates the subject uid parameter and related filter.