### PR TITLE
dcache-xroot (5.2): Add info logging to track session and channel

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -188,11 +188,16 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 if (descriptor.isPersistOnSuccessfulClose()) {
                     descriptor.getChannel().release(new FileCorruptedCacheException(
                             "File was opened with Persist On Successful Close and not closed."));
+                    _log.info("Channel {}, channelInactive, File was opened with Persist On Successful Close and not closed; releasing channel.",
+                        ctx.channel().id());
                 } else if (descriptor.getChannel().getIoMode().contains(StandardOpenOption.WRITE)) {
                     descriptor.getChannel().release(new CacheException(
                             "Client disconnected without closing file."));
+                    _log.info("Channel {}, channelInactive, Client disconnected without closing file; releasing channel.",
+                        ctx.channel().id());
                 } else {
                     descriptor.getChannel().release();
+                    _log.info("Channel {}, channelInactive; releasing channel.", ctx.channel().id());
                 }
             }
         }
@@ -202,7 +207,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t)
     {
         if (t instanceof ClosedChannelException) {
-            _log.info("Connection {} unexpectedly closed.", ctx.channel());
+            _log.info("Channel {} unexpectedly closed.", ctx.channel().id());
         } else if (t instanceof Exception) {
             for (FileDescriptor descriptor : _descriptors) {
                 if (descriptor != null) {
@@ -213,6 +218,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                     } else {
                         descriptor.getChannel().release(t);
                     }
+
+                    _log.info("Channel {}, execptionCaught {}, releasing channel {}.",
+                        ctx.channel().id(), t.getMessage());
 
                     if (descriptor instanceof TpcWriteDescriptor) {
                         ((TpcWriteDescriptor)descriptor).fireDelayedSync(kXR_error,
@@ -236,10 +244,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         /*
          * It is only necessary to tell the client to observe the unix protocol
          * if security is on and signed hashes are being enforced.
-         *
          * We also need to swap the decoder.
          */
         String sec;
+
+        _log.info("(Channel {}, Session {}): login.", ctx.channel().id(), sessionId);
 
         if (signingPolicy.isSigningOn() && signingPolicy.isForceSigning()) {
             sec = "&P=unix";
@@ -284,8 +293,10 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         try {
             Map<String, String> opaqueMap = getOpaqueMap(msg.getOpaque());
             UUID uuid = getUuid(opaqueMap);
+
             if (uuid == null) {
-                _log.info("Request to open {} contains no UUID.", msg.getPath());
+                _log.info("(Channel {} Session {}): Request to open {} contains no UUID.",
+                    ctx.channel().id(), msg.getSession().getSessionIdentifier(), msg.getPath());
                 throw new XrootdException(kXR_NotAuthorized, "Request lacks the "
                                 + UUID_PREFIX + " property.");
             }
@@ -293,7 +304,8 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
             NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel file
                             = _server.openFile(uuid, false);
             if (file == null) {
-                _log.info("No mover found for {} with UUID {}.", msg.getPath(), uuid);
+                _log.info("(Channel {} Session {}): No mover found for {} with UUID {}.",
+                    ctx.channel().id(), msg.getSession().getSessionIdentifier(), msg.getPath(), uuid);
                 return redirectToDoor(ctx, msg, () ->
                 {
                     throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX
@@ -313,7 +325,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                                     file.getProtocolInfo().getFlags()
                                         .contains(XrootdProtocolInfo.Flags.POSC);
                     if (opaqueMap.containsKey("tpc.src")) {
-                        _log.debug("Request to open {} is as third-party destination.", msg);
+                        _log.debug("Request to open {} is as third-party destination.", msg);
 
                         XrootdTpcInfo tpcInfo = new XrootdTpcInfo(opaqueMap);
                         tpcInfo.setDelegatedProxy(file.getProtocolInfo().getDelegatedCredential());
@@ -655,6 +667,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     {
         int fd = msg.getFileHandle();
 
+        _log.info("(Channel {} Session {}): received request to close {}, fd {}.",
+            ctx.channel().id(), msg.getSession().getSessionIdentifier(), fd);
+
         if (!isValidFileDescriptor(fd)) {
             _log.warn("Could not find file descriptor for handle {}", fd);
             throw new XrootdException(kXR_FileNotOpen,
@@ -694,6 +709,8 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         case kXR_Qconfig:
             StringBuilder s = new StringBuilder();
             for (String name: msg.getArgs().split(" ")) {
+                _log.info("(Channel {}, Session: {}): query request kXR_Qconfig, {}.",
+                    ctx.channel().id(), msg.getSession().getSessionIdentifier(), name);
                 switch (name) {
                 case "bind_max":
                     s.append(0);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
@@ -18,22 +18,21 @@
 package org.dcache.xrootd.pool;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.CellCommandListener;
+import dmg.cells.nucleus.CellPath;
+import dmg.util.command.Argument;
+import dmg.util.command.Command;
+import dmg.util.command.Option;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.annotation.Resource;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.nio.channels.CompletionHandler;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,15 +41,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
-import diskCacheV111.util.CacheException;
-
-import dmg.cells.nucleus.CellCommandListener;
-import dmg.cells.nucleus.CellPath;
-import dmg.util.command.Argument;
-import dmg.util.command.Command;
-import dmg.util.command.Option;
-
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
 import org.dcache.pool.movers.NettyMover;
 import org.dcache.pool.movers.NettyTransferService;
 import org.dcache.util.CDCThreadFactory;
@@ -64,6 +57,9 @@ import org.dcache.xrootd.plugins.ChannelHandlerFactory;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.security.SigningPolicy;
 import org.dcache.xrootd.stream.ChunkedResponseWriteHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
 
 /**
  * xrootd transfer service.
@@ -172,6 +168,18 @@ public class XrootdTransferService extends NettyTransferService<XrootdProtocolIn
                         .setNameFormat("xrootd-tpc-client-%d")
                         .build();
         thirdPartyClientGroup = new NioEventLoopGroup(0, new CDCThreadFactory(factory));
+    }
+
+    @Override
+    public void closeMover(NettyMover<XrootdProtocolInfo> mover,
+        CompletionHandler<Void, Void> completionHandler) {
+        LOGGER.info("closeMover ({}) (protocol {}) (UUID {}) (path {}) (error {}).",
+            mover,
+            mover.getProtocolInfo(),
+            mover.getUuid(),
+            mover.getTransferPath(),
+            mover.getErrorMessage());
+        super.closeMover(mover, completionHandler);
     }
 
     @Required


### PR DESCRIPTION
Adds extra logging to be able to determine when sessions open
and close files and when movers are closed.

Target: 5.2
Acked-by: Dmitry