### PR TITLE
dcache-xroot (5.2): Add info logging to track session and channel (re…

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.xrootd;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,8 @@ import org.dcache.util.Checksum;
 import org.dcache.util.Checksums;
 import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.core.XrootdRequestHandler;
+import org.dcache.xrootd.core.XrootdSession;
+import org.dcache.xrootd.core.XrootdSessionIdentifier;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.protocol.messages.LocateRequest;
 import org.dcache.xrootd.protocol.messages.LocateResponse;
@@ -37,6 +40,7 @@ import org.dcache.xrootd.protocol.messages.QueryRequest;
 import org.dcache.xrootd.protocol.messages.QueryResponse;
 import org.dcache.xrootd.protocol.messages.SetRequest;
 import org.dcache.xrootd.protocol.messages.SetResponse;
+import org.dcache.xrootd.protocol.messages.XrootdRequest;
 import org.dcache.xrootd.protocol.messages.XrootdResponse;
 import org.dcache.xrootd.security.SigningPolicy;
 import org.dcache.xrootd.util.ChecksumInfo;
@@ -125,4 +129,21 @@ public class AbstractXrootdRequestHandler extends XrootdRequestHandler
                         + "for this file.");
     }
 
+    // REVISIT DEBUGGING CODE
+    protected void handleLoggingForSessionInfo(ChannelHandlerContext ctx,
+                                               XrootdRequest request,
+                                               Logger logger,
+                                               String format,
+                                               Object ... args) {
+        Channel channel = ctx.channel();
+        XrootdSession session = request.getSession();
+        XrootdSessionIdentifier sessionId = null;
+
+        if (session != null) {
+            sessionId = session.getSessionIdentifier();
+        }
+
+        logger.info("Channel {}, Session {}: " + format,
+                    channel, sessionId, args);
+    }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -216,8 +216,9 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                 opaque = new HashMap<>();
             }
         } catch (ParseException e) {
-            _log.warn("Ignoring malformed open opaque {}: {}", req.getOpaque(),
-                      e.getMessage());
+            handleLoggingForSessionInfo(ctx, req, _log,
+                                        "Ignoring malformed open opaque {}: {}",
+                                        req.getOpaque(), e.getMessage());
             opaque = new HashMap<>();
         }
 
@@ -234,8 +235,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             }
 
             FilePerm neededPerm = req.getRequiredPermission();
+            handleLoggingForSessionInfo(ctx, req, _log,
+                                        "Opening {} for {}",
+                                        req.getPath(), neededPerm.xmlText());
 
-            _log.info("Opening {} for {}", req.getPath(), neededPerm.xmlText());
             if (_log.isDebugEnabled()) {
                 logDebugOnOpen(req);
             }
@@ -252,6 +255,9 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                 _log.warn("Ignoring malformed oss.asize: {}",
                           exception.getMessage());
             }
+
+            handleLoggingForSessionInfo(ctx, req, _log,
+                                        "OPAQUE : {}", opaque);
 
             UUID uuid = UUID.randomUUID();
             opaque.put(UUID_PREFIX, uuid.toString());
@@ -764,6 +770,9 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         case kXR_Qconfig:
             StringBuilder s = new StringBuilder();
             for (String name: msg.getArgs().split(" ")) {
+                handleLoggingForSessionInfo(ctx, msg, _log,
+                                            "query request kXR_Qconfig, {}.",
+                                            name);
                 switch (name) {
                 case "bind_max":
                     s.append(0);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ReadDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ReadDescriptor.java
@@ -1,5 +1,8 @@
 package org.dcache.xrootd.pool;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -15,10 +18,12 @@ import org.dcache.xrootd.util.ByteBuffersProvider;
  */
 public class ReadDescriptor implements FileDescriptor
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReadDescriptor.class);
+
     /**
      * Update mover meta-information
      */
-    protected NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel _channel;
+    protected            NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel _channel;
 
     public ReadDescriptor(NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel channel)
     {
@@ -28,13 +33,20 @@ public class ReadDescriptor implements FileDescriptor
     @Override
     public void read(ByteBuffer buffer, long position) throws IOException
     {
-        while (buffer.hasRemaining()) {
-            /* use position independent thread safe call */
-            int bytes = _channel.read(buffer, position);
-            if (bytes < 0) {
-                break;
+        try {
+            while (buffer.hasRemaining()) {
+                /* use position independent thread safe call */
+                int bytes = _channel.read(buffer, position);
+                if (bytes < 0) {
+                    break;
+                }
+                position += bytes;
             }
-            position += bytes;
+        } catch (RuntimeException | IOException e) {
+            Throwable t = e.getCause();
+            LOGGER.error("Intercepting error thrown during buffer read: {}; cause {}.",
+                e.getMessage(), t == null ? "cause not reported" : t.getMessage());
+            throw e;
         }
     }
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -188,11 +188,16 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 if (descriptor.isPersistOnSuccessfulClose()) {
                     descriptor.getChannel().release(new FileCorruptedCacheException(
                             "File was opened with Persist On Successful Close and not closed."));
+                    _log.info("Channel {}, channelInactive, File was opened with Persist On Successful Close and not closed; releasing channel.",
+                        ctx.channel());
                 } else if (descriptor.getChannel().getIoMode().contains(StandardOpenOption.WRITE)) {
                     descriptor.getChannel().release(new CacheException(
                             "Client disconnected without closing file."));
+                    _log.info("Channel {}, channelInactive, Client disconnected without closing file; releasing channel.",
+                        ctx.channel());
                 } else {
                     descriptor.getChannel().release();
+                    _log.info("Channel {}, channelInactive; releasing channel.", ctx.channel());
                 }
             }
         }
@@ -202,7 +207,10 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t)
     {
         if (t instanceof ClosedChannelException) {
-            _log.info("Connection {} unexpectedly closed.", ctx.channel());
+            Throwable c = t.getCause();
+            _log.info("Channel {} unexpectedly closed {}: {}",
+                      ctx.channel(), t.getMessage(),
+                      c == null ? "cause not reported": c.getMessage());
         } else if (t instanceof Exception) {
             for (FileDescriptor descriptor : _descriptors) {
                 if (descriptor != null) {
@@ -213,6 +221,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                     } else {
                         descriptor.getChannel().release(t);
                     }
+
+                    _log.info("Channel {}, execptionCaught {}, releasing channel.",
+                        ctx.channel(), t.getMessage());
 
                     if (descriptor instanceof TpcWriteDescriptor) {
                         ((TpcWriteDescriptor)descriptor).fireDelayedSync(kXR_error,
@@ -236,10 +247,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         /*
          * It is only necessary to tell the client to observe the unix protocol
          * if security is on and signed hashes are being enforced.
-         *
          * We also need to swap the decoder.
          */
         String sec;
+
+        handleLoggingForSessionInfo(ctx, msg, _log,"login.");
 
         if (signingPolicy.isSigningOn() && signingPolicy.isForceSigning()) {
             sec = "&P=unix";
@@ -284,8 +296,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         try {
             Map<String, String> opaqueMap = getOpaqueMap(msg.getOpaque());
             UUID uuid = getUuid(opaqueMap);
+
             if (uuid == null) {
-                _log.info("Request to open {} contains no UUID.", msg.getPath());
+                handleLoggingForSessionInfo(ctx, msg, _log,
+                                            "Request to open {} contains no UUID.",
+                                            msg.getPath());
                 throw new XrootdException(kXR_NotAuthorized, "Request lacks the "
                                 + UUID_PREFIX + " property.");
             }
@@ -293,7 +308,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
             NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel file
                             = _server.openFile(uuid, false);
             if (file == null) {
-                _log.info("No mover found for {} with UUID {}.", msg.getPath(), uuid);
+                handleLoggingForSessionInfo(ctx, msg, _log,
+                                            "No mover found for {} with UUID {}.",
+                                            msg.getPath(), uuid);
                 return redirectToDoor(ctx, msg, () ->
                 {
                     throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX
@@ -313,7 +330,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                                     file.getProtocolInfo().getFlags()
                                         .contains(XrootdProtocolInfo.Flags.POSC);
                     if (opaqueMap.containsKey("tpc.src")) {
-                        _log.debug("Request to open {} is as third-party destination.", msg);
+                        _log.debug("Request to open {} is as third-party destination.", msg);
 
                         XrootdTpcInfo tpcInfo = new XrootdTpcInfo(opaqueMap);
                         tpcInfo.setDelegatedProxy(file.getProtocolInfo().getDelegatedCredential());
@@ -655,6 +672,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     {
         int fd = msg.getFileHandle();
 
+        handleLoggingForSessionInfo(ctx, msg, _log,
+                                    "received request to close {}.", fd);
+
         if (!isValidFileDescriptor(fd)) {
             _log.warn("Could not find file descriptor for handle {}", fd);
             throw new XrootdException(kXR_FileNotOpen,
@@ -694,6 +714,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         case kXR_Qconfig:
             StringBuilder s = new StringBuilder();
             for (String name: msg.getArgs().split(" ")) {
+                handleLoggingForSessionInfo(ctx, msg, _log,
+                                            "query request kXR_Qconfig, {}.",
+                                            name);
                 switch (name) {
                 case "bind_max":
                     s.append(0);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -178,6 +178,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     public void channelInactive(ChannelHandlerContext ctx)
             throws Exception
     {
+        _log.info("Channel {}, channelInactive.", ctx.channel());
         /* close leftover descriptors */
         for (FileDescriptor descriptor : _descriptors) {
             if (descriptor != null) {
@@ -206,6 +207,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t)
     {
+        _log.info("Channel {}, exceptionCaught: {}", ctx.channel(), t.toString());
         if (t instanceof ClosedChannelException) {
             Throwable c = t.getCause();
             _log.info("Channel {} unexpectedly closed {}: {}",

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
@@ -34,6 +34,7 @@ import javax.annotation.Resource;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.nio.channels.CompletionHandler;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -172,6 +173,18 @@ public class XrootdTransferService extends NettyTransferService<XrootdProtocolIn
                         .setNameFormat("xrootd-tpc-client-%d")
                         .build();
         thirdPartyClientGroup = new NioEventLoopGroup(0, new CDCThreadFactory(factory));
+    }
+
+    @Override
+    public void closeMover(NettyMover<XrootdProtocolInfo> mover,
+        CompletionHandler<Void, Void> completionHandler) {
+        LOGGER.info("closeMover ({}) (protocol {}) (UUID {}) (path {}) (error {}).",
+            mover,
+            mover.getProtocolInfo(),
+            mover.getUuid(),
+            mover.getTransferPath(),
+            mover.getErrorMessage());
+        super.closeMover(mover, completionHandler);
     }
 
     @Required

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/NettyTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/NettyTransferService.java
@@ -245,6 +245,7 @@ public abstract class NettyTransferService<P extends ProtocolInfo>
             @Override
             public void channelInactive(ChannelHandlerContext ctx) throws Exception
             {
+                LOGGER.info("Channel {}, channelInactive.", ctx.channel());
                 super.channelInactive(ctx);
                 openChannels.remove(ctx.channel());
                 conditionallyStopServer();


### PR DESCRIPTION
…vised)

    Adds extra logging to be able to determine when sessions open
    and close files and when movers are closed.
    Wraps the exceptions thrown by the channel read.

    Target: 5.2